### PR TITLE
Fix button disabled state accessibility

### DIFF
--- a/src/widgets/Button.js
+++ b/src/widgets/Button.js
@@ -358,6 +358,11 @@ Ext.Button = Ext.extend(Ext.BoxComponent, {
     // private
     initButtonEl : function(btn, btnEl){
         this.el = btn;
+        if(this.disabled){
+            this.el.dom.setAttribute('aria-disabled', true);
+            btnEl.dom.setAttribute('aria-disabled', true);
+            btnEl.dom.disabled = true;
+        }
         this.setIcon(this.icon);
         this.setText(this.text);
         this.setIconClass(this.iconCls);
@@ -597,6 +602,11 @@ Ext.Button = Ext.extend(Ext.BoxComponent, {
                 this.el[disabled ? 'addClass' : 'removeClass'](this.disabledClass);
             }
             this.el.dom.disabled = disabled;
+            this.el.dom.setAttribute('aria-disabled', disabled);
+        }
+        if(this.btnEl){
+            this.btnEl.dom.disabled = disabled;
+            this.btnEl.dom.setAttribute('aria-disabled', disabled);
         }
         this.disabled = disabled;
     },


### PR DESCRIPTION
## Summary
- add `aria-disabled` handling to `Ext.Button`
- set disabled state on button element

## Testing
- `npm run build` *(fails: gulp not found)*
- `npm run axe -- examples/button/buttons.html` *(fails: ts-node not found)*

------
https://chatgpt.com/codex/tasks/task_b_6866233a3d30832eaebf673e26a34a2b