### PR TITLE
Enable keyboard navigation for toolbar

### DIFF
--- a/test/unit/widgets/Toolbar.js
+++ b/test/unit/widgets/Toolbar.js
@@ -1,0 +1,37 @@
+/*!
+ * Ext JS Library 3.4.0
+ */
+(function(){
+    var suite = Ext.test.session.getSuite('Ext.Toolbar'),
+        assert = Y.Assert;
+
+    suite.add(new Y.Test.Case({
+        name: 'Keyboard navigation',
+
+        setUp: function(){
+            this.tb = new Ext.Toolbar({
+                renderTo: Ext.getBody(),
+                items: [
+                    {text: 'One'},
+                    {text: 'Two'},
+                    {text: 'Three'}
+                ]
+            });
+        },
+
+        tearDown: function(){
+            this.tb.destroy();
+        },
+
+        testArrowNavigation: function(){
+            var els = this.tb.focusableEls;
+            assert.areEqual(0, els[0].dom.tabIndex);
+            assert.areEqual(-1, els[1].dom.tabIndex);
+            this.tb.moveFocus(1);
+            assert.areEqual(0, els[1].dom.tabIndex);
+            assert.areEqual(-1, els[0].dom.tabIndex);
+            this.tb.moveFocus(-1);
+            assert.areEqual(0, els[0].dom.tabIndex);
+        }
+    }));
+})();


### PR DESCRIPTION
## Summary
- add roving tabindex support and left/right keyboard navigation in `Ext.Toolbar`
- add regression test for toolbar key navigation

## Testing
- `npm run build` *(fails: gulp not found)*
- `npm run axe -- toolbar/toolbars.html` *(fails: ts-node not found)*

------
https://chatgpt.com/codex/tasks/task_b_6866329151b4832e90e2f07f32c909cf