### PR TITLE
Add keyboard navigation to ColorPalette

### DIFF
--- a/test/unit/widgets/ColorPalette.js
+++ b/test/unit/widgets/ColorPalette.js
@@ -1,0 +1,34 @@
+(function(){
+    var suite = Ext.test.session.getSuite('Ext.ColorPalette'),
+        assert = Y.Assert;
+
+    suite.add(new Y.Test.Case({
+        name: 'keyboard navigation',
+
+        setUp: function(){
+            this.palette = new Ext.ColorPalette({
+                renderTo: Ext.getBody(),
+                value: '000000'
+            });
+        },
+
+        tearDown: function(){
+            this.palette.destroy();
+        },
+
+        testArrowNavigationSelect: function(){
+            var e = new Ext.EventObjectImpl(),
+                selected;
+
+            this.palette.on('select', function(p, c){ selected = c; });
+
+            e.keyCode = 39; // right
+            this.palette.keyNav.relay(e);
+            e = new Ext.EventObjectImpl();
+            e.keyCode = 32; // space
+            this.palette.keyNav.relay(e);
+
+            assert.areEqual(this.palette.colors[1], selected);
+        }
+    }));
+})();


### PR DESCRIPTION
## Summary
- improve `ColorPalette` accessibility with keyboard support
- add unit test for keyboard color selection

## Testing
- `npm run build` *(fails: gulp not found)*
- `npm run axe -- menu/menus.html` *(fails: ts-node not found)*

------
https://chatgpt.com/codex/tasks/task_b_686634bb5d30832ea02b4be98a4d8957