### PR TITLE
Fix focus outline visibility

### DIFF
--- a/resources/css/ext-all-notheme.css
+++ b/resources/css/ext-all-notheme.css
@@ -5324,3 +5324,8 @@ body.ext-ie6.x-body-masked .x-window select {
 .ext-gecko2 .ext-mb-fix-cursor {
     overflow:auto;
 }
+
+/* visible focus indicator */
+*:focus {
+    outline: 1px dotted #000 !important;
+}

--- a/resources/css/ext-all.css
+++ b/resources/css/ext-all.css
@@ -6991,3 +6991,8 @@ body.x-body-masked .x-window-plain .x-window-mc {
 .x-window-dlg .ext-mb-error {
     background-image:url(../images/default/window/icon-error.gif);
 }
+
+/* visible focus indicator */
+*:focus {
+    outline: 1px dotted #000 !important;
+}


### PR DESCRIPTION
## Summary
- add dotted outline for all focused elements in ext-all.css
- add dotted outline for all focused elements in ext-all-notheme.css

## Testing
- `npm run build`
- `npm run axe -- form/absform.html` *(fails: browsers not installed)*

------
https://chatgpt.com/codex/tasks/task_b_6866434424b4832e8e815b58ad4056c8