### PR TITLE
Remove webkit focus outline override

### DIFF
--- a/docs/resources/css/ext-all.css
+++ b/docs/resources/css/ext-all.css
@@ -857,9 +857,6 @@ ul.x-tab-strip li.x-tab-edge {
     margin: 0 0 0 0;
 }
 
-.ext-webkit *:focus{
-    outline: none !important;
-}
 
 /* ---- text fields ---- */
 .x-form-text, textarea.x-form-field{

--- a/docs/resources/ext-all.css
+++ b/docs/resources/ext-all.css
@@ -857,9 +857,6 @@ ul.x-tab-strip li.x-tab-edge {
     margin: 0 0 0 0;
 }
 
-.ext-webkit *:focus{
-    outline: none !important;
-}
 
 /* ---- text fields ---- */
 .x-form-text, textarea.x-form-field{

--- a/resources/css/ext-all-notheme.css
+++ b/resources/css/ext-all-notheme.css
@@ -879,9 +879,6 @@ ul.x-tab-strip li.x-tab-edge {
     margin: 0 0 0 0;
 }
 
-.ext-webkit *:focus{
-    outline: none !important;
-}
 
 /* ---- text fields ---- */
 .x-form-text, textarea.x-form-field{

--- a/resources/css/ext-all.css
+++ b/resources/css/ext-all.css
@@ -879,9 +879,6 @@ ul.x-tab-strip li.x-tab-edge {
     margin: 0 0 0 0;
 }
 
-.ext-webkit *:focus{
-    outline: none !important;
-}
 
 /* ---- text fields ---- */
 .x-form-text, textarea.x-form-field{

--- a/resources/css/structure/form.css
+++ b/resources/css/structure/form.css
@@ -9,9 +9,6 @@
     margin: 0 0 0 0;
 }
 
-.ext-webkit *:focus{
-    outline: none !important;
-}
 
 /* ---- text fields ---- */
 .x-form-text, textarea.x-form-field{


### PR DESCRIPTION
## Summary
- remove deprecated `.ext-webkit *:focus` CSS rule from generated styles

## Testing
- `npm test` *(fails: no test specified)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_b_686646f522e4832eacc4c0f501b74bf0